### PR TITLE
Add refinements, sections on CVFR and mixed representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,19 @@
 
 Porcino & Steinbach, Dec 2024
 
+--------------------------------------------------------------------------------
 ## Abstract
 
 We investigate common assumptions about the representation of time values as an ordinate on a number line, and the impact of representation on computations.
 
 We show the largest values representable, and when the math on various reprsentations stops being exact to various degrees, such as being off by a millisecond, or a half of a frame.
 
+--------------------------------------------------------------------------------
 ### TL/DR:
 
 See the machine generated results this project generates: [results.md](results.md)
 
+--------------------------------------------------------------------------------
 ## Introduction
 
 It is common lore that timelines such as those found in editorial NLEs must represent time ordinates with rational integers. In order to prove this we will hit the lore with the rational sledgehammer of the scientific method by constructing a falsifiable hypothesis, H, that a floating point value is sufficient to the purpose. Results to date are provided below which are not sufficient to disprove the hypothesis.
@@ -41,12 +44,13 @@ For rates defined as 30/1.001 or 24/1.001, system implementers typically use rat
 
 ### Floating Point Pitfalls
 
-Floating-point numbers can accumulate errors in long computations due to rounding, especially in iterative operations like time summation or phase adjustments.
+Floating-point numbers can accumulate errors in long computations due to rounding, especially in iterative operations like time summation or phase adjustments. In particular, when the representation of a value exceeds the number of bits available in the mantissa, the exponent must be adjusted, and precision is irreversibly lost.
+
 "Half-frame" or sub-frame inaccuracies in calculations (such as summing 23.976023976023978 repeatedly) would cause perceptible artifacts like audio drift or misaligned frames.
 
 ### Rational Integer Pitfalls
 
-There is a fallacy in the logic promoted popularly. As a point in case, CMTime[^7] as used in QuickTime uses rational integers. However, experimentation demonstrates that CMTime, and in fact all robust rational integer implementations must renormalize, particularly in the case of time warps. Mixing two NTSC rates gives as a LCD of 1001 * 1001, and that can compound exponentially with every operation involving mixed rates. A robust implementation like CMTime must invoke a renormalization whenever a maximum bit count is exceeded and thus becomes lossy. This error emerges discretely when bit width capacities are exceeded.
+There is a fallacy in the logic promoted popularly. As a point in case, CMTime[^7] as used in QuickTime uses rational integers. However, experimentation demonstrates that CMTime, and in fact all robust rational integer implementations must renormalize, particularly in the case of time warps. Mixing two NTSC rates gives as a LCD of 1001 * 1001, and that can compound exponentially with every operation involving mixed rates. A robust implementation like CMTime must invoke a renormalization whenever a maximum bit count is exceeded and thus becomes lossy and irreversible. This error emerges discretely when bit width capacities are exceeded.
 
 This test is demonstrable by the "Integer Rational Sum/Product test" in our results, which shows that after 2145342 (when the multiply rolls over) we lose a bit of precision and the two numbers are now off by one.
 
@@ -54,24 +58,63 @@ Quilez[^2], in section "Detour - on coprime numbers" illustrates a fundamental i
 
 The low efficiency of the representation and the need for renormalization and its associated lossy behavior is an underappreciated drawback of rational representations, and "rational is perfect" lore seems not to hold up to scrutiny.
 
-## Further Notes - "Factorized Integers"
+For specific applications like MIDI timestamps or embedded systems with fixed-rate clocks, rational representations may still be preferable due to hardware constraints.
+
+### Rational Floats
+
+Some systems hedge their bets with a floating point value that is an index over a floating point rate. This representation offers dramatically improved precision in the case where the rate is a repeating fraction. Although this extra precision pays off in fixed rate application, the same pitfalls as occur in rational integers when rates are mixed. When rational integers are mixed, renormalization occurs when bit width is exceeded; similarly when rational floats are mixed, renormalization occurs when mantissa bit width is exceeded and the exponent is increased. As with rational integers the precision loss that occurs then is lossy and irreversible.
+
+### Factorized Integers
 
 Another less common approach in the community is to use what we refer to as a "factorized integer" - an integer that is an index over an implicit rate.  The rate is a large number that is a common factor of a common media rates.  See [^8] and [^9].  These are bounded by both by integer limits, especially for coarser rates and also cannot handle non-integer multiplication or rates whose factors are not present in their rate.  We've included them in the data limits table.
 
+### Sampling and Interpolation
 
-## Overview of Method
+These experiments demonstrate, for a variety of representations, the numeric limits at which a time ordinate unmistakably corresponds to a particular frame at a given framerate. In the regime close to these limits, accurate subsampling and interpolation are not possible due to the fact that the numbers are at the limits of their representation. However, a consequence of the fact that the ordinates are distinguishable at rate means that they can be reversibly be moved to the origin and back again. So, a system that must perform sampling and interpolation may reliably do so by translating a sequence of interest close to the origin and sampling accurately there, as long as it make sense to do the sampling or interpolation in a local frame of reference.
+
+### Continuously Variable Framerate
+
+Continuously variable framerate (CVFR) in modern smartphone cameras operates on a discrete sensor readout clock, typically at a high frequency (e.g., 240 Hz in some configurations). However, the output framerate is not achieved by simple frame skipping; rather, it is dynamically controlled through a combination of exposure time, gain, and readout timing adjustments.
+
+Rather than continuously recording at a fixed high framerate and discarding frames, the system dynamically adjusts exposure duration and readout intervals to achieve a desired output framerate while maintaining synchronization with the rolling shutter scan. This allows for adaptive framerate changes in response to lighting conditions, motion, or energy efficiency considerations.
+
+Frames can be synthesized at the target rate through selective readout, integration, and interpolation techniques, rather than merely dropping frames from a fixed high-rate sequence. This approach optimizes image quality while allowing for framerate flexibility within the constraints of the sensor's rolling shutter and exposure control mechanisms.
+
+Since CVFR systems operate on a discrete readout clock, the precision analysis discussed earlier applies directly. The readout timing and exposure adjustments introduce constraints on exact frame alignment, meaning precision limits are dictated by the granularity of the underlying clock. As with other time representations, cumulative errors may emerge when approximations or truncations occur over extended sequences. Additionally, factors such as sensor clock jitter and temperature-induced timing variations should be considered in long-duration recording scenarios.
+
+--------------------------------------------------------------------------------
+
+## Practical Implications for Timestamping in Mixed Environments
+
+In digital post-production systems that ingest both floating point and rational timecodes, timestamping introduces practical challenges. Mixed environments must reconcile the precision limitations of each format to ensure accurate synchronization and avoid drift over time.
+
+Mixed-format workflows demand robust error handling and reconciliation strategies to ensure that time ordinates remain stable across different computational paradigms.
+
+### Precision Handling
+
+Systems must account for the lossy nature of floating-point arithmetic and the potential for integer rational representations to require renormalization. Differences in rounding strategies between formats can lead to cumulative errors over long durations.
+
+### Interpolation Techniques
+
+When converting between rational and floating-point timestamps, careful interpolation is required to maintain frame alignment. Simple rounding may introduce inconsistencies that manifest as subtle timing artifacts.
+
+### Metadata and Provenance
+
+Maintaining metadata about the original timecode format can help mitigate errors when performing format conversions. Systems that explicitly track whether a timestamp originated from a rational or floating-point source can apply format-specific correction strategies.
+
+--------------------------------------------------------------------------------
+
+## Overview of the Method
 
 A series of tests to explore floating point accuracy over large number ranges.
 
 ## Falsifiable Hypothesis
 
-Attempting to prove that a rational with an integer component is necessary to
-maintain precision over large time scales and under math.
+A double precision number is sufficient to maintain precision over large time scales and under math.
 
 ## Methodology
 
-Construct double precision values that fail precision tests thus requiring an
-integer rational.
+Construct double precision values that fail precision tests thus requiring another representation. Show that another representation provides more precision; repeat.
 
 ### Accumulation
 
@@ -93,7 +136,8 @@ Test Case: Verify sub-frame accuracy over long durations
 
 Test Case: Demonstrate exacerbation of error resulting from mixed mathematical oeprations.
 
-## How to Use
+--------------------------------------------------------------------------------
+## Running the Experiments
 
 1. Install Zig 0.13.0
 2. run:
@@ -109,15 +153,19 @@ To run a specific test:
 
 `zig test -I. main.zig --test-filter "name_of_test"`
 
+--------------------------------------------------------------------------------
 ## Results
 
 See: [results.md](results.md)
 
+--------------------------------------------------------------------------------
 ## Conclusions
 
 * We have a number of tests that explore the accuracy of a variety of number
   representations present in audio/video engineering, including integer
   rational, and various bit depths of floating point number.
+* Different representations offer different precision limits; this work offers
+  insight into which representation to choose for a domain of interest.
 * If your system does not require time warps, than integers, or "factorized
   integers"/integer rationals (if you're not mixing rates) are probably
   sufficient.
@@ -138,6 +186,7 @@ See: [results.md](results.md)
   into the other space such as occurs when fetching an audio sample during a
   long running video timeline.
 
+--------------------------------------------------------------------------------
 ## Todo List
 
 
@@ -146,7 +195,11 @@ See: [results.md](results.md)
 * [ ] worth noting the difference between f32->f64->f128 and integer rational
   i32->i64 etc.
 * [ ] Fold other references from [^1] into the document.
+* [ ] Verify the sampling hypothesis that numbers near the limit may be
+  reversibly brought near the origin and put back again
 
+
+--------------------------------------------------------------------------------
 ## Appendix: Data limits of number types
 
 | Type | Bits of Integer Precision | Maximum Integer Value | Max Integer Hours@192KHz (~5.2µs) | Max Integer Years@192Hz (~5.2µs) |
@@ -157,6 +210,8 @@ See: [results.md](results.md)
 | int64_t | 63 | 9.22337E+18 | 13343998896 | 1523287.545 |
 | uint64_t | 64 | 1.84467E+19 | 26687997792 | 3046575.09 |
 
+
+--------------------------------------------------------------------------------
 ## References
 
 [^1]: Original OpenTimelineIO research on Ordinate types in editorial formats: https://docs.google.com/spreadsheets/d/1JMwBMJuAUEzJFfPHUnI1AbFgIWuIdBkzVEUF80cx6l4/edit?usp=sharing


### PR DESCRIPTION
Overall editorial pass. Added sections on sampling and interpolation. Added cvfr and mixed representations

Addressed comments at:
https://github.com/ssteinbach/ordinate_precision_research/issues/9